### PR TITLE
Menambah option ssl untuk endpoint api & Fix Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ composer require lintangtimur/cek-pajak-api
 use Stelin\CekPajakApi\CekPajak;
 
 $form = [
-    "name"=> 'lintang',
+    'name'=> 'lintang',
     'email'=> 'lintang@gmail.com',
     'password'=>'123456'
 ];
 
-$reg = new CekPajak()
+$reg = new CekPajak();
 $reg = (new CekPajak)->register($form);
 ```
 
@@ -36,12 +36,12 @@ $reg = (new CekPajak)->register($form);
 use Stelin\CekPajakApi\CekPajak;
 
 $form = [
-    "name"=> 'lintang',
+    'name'=> 'lintang',
     'email'=> 'lintang@gmail.com',
     'password'=>'123456'
 ];
 
-$login = new CekPajak()
+$login = new CekPajak();
 $login = (new CekPajak)->login($form)->accessToken;
 ```
 
@@ -50,9 +50,25 @@ $login = (new CekPajak)->login($form)->accessToken;
 <?php
 use Stelin\CekPajakApi\CekPajak;
 
-$cp = new CekPajak($accessToken)
+$cp = new CekPajak($accessToken);
 $cp->cekPajak('H','1234','AA')->totalPkbPokok;
 
 //Melihat rincian akhir pajak
 $a->cekPajak('H','1234','AA')->rincian->masaAkhirBerlakuPajak;
+```
+
+#### Contoh menggunakan SSL
+Menambah option penggunaan ssl untuk endpoint api untuk user yang mengalami error ```SSL certificate problem```
+```php
+$form = [
+    'name'=> 'lintang',
+    'email'=> 'lintang@gmail.com',
+    'password'=>'123456'
+];
+
+$login = new CekPajak();
+$accessToken = $login->ssl(true)->login($form)->accessToken; //registrasi terlebih dahulu sebelum login
+$accsess = new CekPajak($accessToken);
+$total_pokok = $accsess->ssl(true)->cekPajak('H','1234','AA')->totalPkbPokok;
+echo $total_pokok;
 ```

--- a/src/CekPajak.php
+++ b/src/CekPajak.php
@@ -17,7 +17,8 @@ class CekPajak
     private $token;
     private $ssl = false;
 
-    public function __construct($token = null) {
+    public function __construct($token = null)
+    {
         $this->token = $token;
     }
 
@@ -27,10 +28,12 @@ class CekPajak
      * @param bool $ssl
      * @return bool
      */
-    public function ssl(bool $ssl){
-        if($ssl == 'true'){
+    public function ssl(bool $ssl)
+    {
+        if ($ssl == 'true') {
             $this->ssl = true;
         }
+
         return $this;
     }
 
@@ -45,7 +48,7 @@ class CekPajak
     public function cekPajak(string $kode_wilayah, string $nomor, string $sub_wilayah)
     {
         $baseurl = 'http' . ($this->ssl ? 's' : '') . '://' . Meta::BASE_URL;
-        $client = new Client();
+        $client  = new Client();
 
         try {
             $res = $client->post($baseurl . 'api/check_pajak', [
@@ -61,7 +64,6 @@ class CekPajak
             $data = json_decode($res->getBody());
 
             return (new PajakResponse())->fromJson($data);
-
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             $response = $e->getResponse();
 
@@ -81,7 +83,8 @@ class CekPajak
      * @param string $sub_wilayah
      * @return string
      */
-    private function generateSignature(string $kode_wilayah, string $nomor, string $sub_wilayah): string {
+    private function generateSignature(string $kode_wilayah, string $nomor, string $sub_wilayah): string
+    {
         return hash_hmac(Meta::ALGO, $kode_wilayah . $nomor . $sub_wilayah, Meta::SIGNKEY);
     }
 
@@ -91,9 +94,10 @@ class CekPajak
      * @param array $formRegister
      * @return void|string
      */
-    public function register(array $formRegister): ?string {
+    public function register(array $formRegister): ?string
+    {
         $baseurl = 'http' . ($this->ssl ? 's' : '') . '://' . Meta::BASE_URL;
-        $client = new Client();
+        $client  = new Client();
 
         try {
             $res = $client->post($baseurl . 'api/auth/register', [
@@ -103,6 +107,7 @@ class CekPajak
             return $res->getBody();
         } catch (\GuzzleHttp\Exception\RequestException $e) {
             $response = $e->getResponse();
+
             return $response ? $response->getBody() : '';
         }
     }
@@ -113,9 +118,10 @@ class CekPajak
      * @param array $formLogin
      * @return LoginEntity
      */
-    public function login(array $formLogin): LoginEntity {
+    public function login(array $formLogin): LoginEntity
+    {
         $baseurl = 'http' . ($this->ssl ? 's' : '') . '://' . Meta::BASE_URL;
-        $client = new Client();
+        $client  = new Client();
 
         try {
             $res = $client->post($baseurl . 'api/auth/login', [
@@ -125,6 +131,7 @@ class CekPajak
             return (new LoginEntity())->fromJson(json_decode($res->getBody()));
         } catch (\GuzzleHttp\Exception\RequestException $e) {
             $response = $e->getResponse();
+
             return $response ? $response->getBody() : '';
         }
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -7,7 +7,7 @@ class Meta
     /**
      * Sementara backend belum siap, masih di local.
      */
-    const BASE_URL = 'https://stelin.xyz/';
+    const BASE_URL = 'stelin.xyz/';
     const SIGNKEY  = 'lintangtimur';
     const ALGO     = 'sha256';
 }


### PR DESCRIPTION
Menambah option penggunaan ssl untuk endpoint api bagi user yang mengalami error ```SSL certificate problem``` saat request curl ke api.

Sering terjadi apabila client tidak menggunakan SSL lalu request ke API yang menggunakan SSL maka akan terjadi error seperti digambar

![image](https://user-images.githubusercontent.com/18723904/235039642-22cd3691-ab1c-48ca-ade6-d4a15855558e.png)


Menambahkan cara contoh penggunaan option ssl dan memperbaiki typos di readme